### PR TITLE
[BUGFIX] Fix player score display name

### DIFF
--- a/src/menu/PlayerGameLabel.gd
+++ b/src/menu/PlayerGameLabel.gd
@@ -27,10 +27,10 @@ func player_scored(player_id: int, score: int):
 	set_player_name()
 
 func build_player_name() -> String:
-	var return_name = contained_player.name + " (" + str(player_score) + ")"
+	var return_name = contained_player.name
 	if contained_player.is_ai():
 		return_name = return_name + " [AI]"
-	return return_name
+	return return_name + " (" + str(player_score) + ")"
 
 func set_player_name():
 	label.text = build_player_name()


### PR DESCRIPTION
The display name for ai players did no match up with the one of human players. This did look odd. This will change the name template to be more consistent.