### PR TITLE
[BUGFIX] crashing loading screen

### DIFF
--- a/src/game/LoadingPath.gd
+++ b/src/game/LoadingPath.gd
@@ -13,3 +13,6 @@ func change_curve():
 	var window_size = get_window().size
 	curve.add_point(Vector2(-width_margin, target_height))
 	curve.add_point(Vector2(window_size.x + width_margin, target_height))
+
+func _exit_tree():
+	get_window().size_changed.disconnect(change_curve)


### PR DESCRIPTION
The loading screen did crash if it was removed from the tree and the Window was resized. This fixes that issue