### PR TITLE
[FEATURE] Improve game end screen visuals

### DIFF
--- a/assets/shaders/ColorReplaceShader.tres
+++ b/assets/shaders/ColorReplaceShader.tres
@@ -1,0 +1,55 @@
+[gd_resource type="VisualShader" load_steps=5 format=3 uid="uid://docbe2j6cd3wg"]
+
+[sub_resource type="VisualShaderNodeColorParameter" id="VisualShaderNodeColorParameter_4tb77"]
+parameter_name = "replace_color"
+
+[sub_resource type="VisualShaderNodeInput" id="VisualShaderNodeInput_sy58d"]
+input_name = "texture"
+
+[sub_resource type="VisualShaderNodeTexture" id="VisualShaderNodeTexture_au28w"]
+source = 5
+
+[sub_resource type="VisualShaderNodeMix" id="VisualShaderNodeMix_y6v80"]
+default_input_values = [0, Vector3(0, 0, 0), 1, Vector3(1, 1, 1), 2, Vector3(1, 1, 1)]
+op_type = 3
+
+[resource]
+code = "shader_type canvas_item;
+render_mode blend_mix;
+
+uniform vec4 replace_color : source_color;
+
+
+
+void fragment() {
+	vec4 n_out4p0;
+// Texture2D:4
+	n_out4p0 = texture(TEXTURE, UV);
+
+
+// ColorParameter:2
+	vec4 n_out2p0 = replace_color;
+
+
+// Mix:5
+	vec3 n_in5p2 = vec3(1.00000, 1.00000, 1.00000);
+	vec3 n_out5p0 = mix(vec3(n_out4p0.xyz), vec3(n_out2p0.xyz), n_in5p2);
+
+
+// Output:0
+	COLOR.rgb = n_out5p0;
+
+
+}
+"
+mode = 1
+flags/light_only = false
+nodes/fragment/2/node = SubResource("VisualShaderNodeColorParameter_4tb77")
+nodes/fragment/2/position = Vector2(-260, 140)
+nodes/fragment/3/node = SubResource("VisualShaderNodeInput_sy58d")
+nodes/fragment/3/position = Vector2(-500, 0)
+nodes/fragment/4/node = SubResource("VisualShaderNodeTexture_au28w")
+nodes/fragment/4/position = Vector2(-220, -40)
+nodes/fragment/5/node = SubResource("VisualShaderNodeMix_y6v80")
+nodes/fragment/5/position = Vector2(120, 40)
+nodes/fragment/connections = PackedInt32Array(3, 0, 4, 2, 4, 0, 5, 0, 5, 0, 0, 0, 2, 0, 5, 1)

--- a/assets/textures/TrophyIcon.tres
+++ b/assets/textures/TrophyIcon.tres
@@ -1,0 +1,7 @@
+[gd_resource type="AtlasTexture" load_steps=2 format=3 uid="uid://dpwyddj6yhp8r"]
+
+[ext_resource type="Texture2D" uid="uid://cg0l7tvqmtghr" path="res://assets/sprites/sheet_white1x.png" id="1_ewhqa"]
+
+[resource]
+atlas = ExtResource("1_ewhqa")
+region = Rect2(109, 164, 32, 28)

--- a/scenes/game/overlay/FinishGame.tscn
+++ b/scenes/game/overlay/FinishGame.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=7 format=3 uid="uid://csamt2tu6hlpo"]
+[gd_scene load_steps=6 format=3 uid="uid://csamt2tu6hlpo"]
 
 [ext_resource type="Script" path="res://src/overlay/GameFinished.gd" id="1_fioaw"]
 [ext_resource type="Script" path="res://src/overlay/PlayerScoreList.gd" id="2_ohkho"]
-[ext_resource type="Script" path="res://src/overlay/PlayerWon.gd" id="2_wslvc"]
 [ext_resource type="PackedScene" uid="uid://pwy03e08f1ov" path="res://scenes/game/overlay/PlayerScoreEntry.tscn" id="3_6aww1"]
 [ext_resource type="Script" path="res://src/overlay/FinishGameOk.gd" id="5_8dsgm"]
 [ext_resource type="Script" path="res://src/overlay/ReplayGame.gd" id="6_f0a12"]
@@ -37,82 +36,83 @@ theme_override_constants/margin_top = 25
 theme_override_constants/margin_right = 25
 theme_override_constants/margin_bottom = 25
 
-[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer/MarginContainer"]
+[node name="VBoxContainer2" type="VBoxContainer" parent="PanelContainer/MarginContainer"]
 layout_mode = 2
 
-[node name="VBoxContainer2" type="VBoxContainer" parent="PanelContainer/MarginContainer/VBoxContainer"]
+[node name="BodyContainer" type="VBoxContainer" parent="PanelContainer/MarginContainer/VBoxContainer2"]
+layout_mode = 2
+
+[node name="PanelContainer" type="PanelContainer" parent="PanelContainer/MarginContainer/VBoxContainer2/BodyContainer"]
+layout_mode = 2
+
+[node name="VBoxContainer2" type="VBoxContainer" parent="PanelContainer/MarginContainer/VBoxContainer2/BodyContainer/PanelContainer"]
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="MarginContainer" type="MarginContainer" parent="PanelContainer/MarginContainer/VBoxContainer/VBoxContainer2"]
+[node name="Header" type="VBoxContainer" parent="PanelContainer/MarginContainer/VBoxContainer2/BodyContainer/PanelContainer/VBoxContainer2"]
+layout_mode = 2
+
+[node name="MarginContainer" type="MarginContainer" parent="PanelContainer/MarginContainer/VBoxContainer2/BodyContainer/PanelContainer/VBoxContainer2/Header"]
 layout_mode = 2
 theme_override_constants/margin_top = 5
-theme_override_constants/margin_bottom = 5
+theme_override_constants/margin_bottom = 0
 
-[node name="RichTextLabel" type="RichTextLabel" parent="PanelContainer/MarginContainer/VBoxContainer/VBoxContainer2/MarginContainer"]
+[node name="RichTextLabel" type="RichTextLabel" parent="PanelContainer/MarginContainer/VBoxContainer2/BodyContainer/PanelContainer/VBoxContainer2/Header/MarginContainer"]
 layout_mode = 2
 size_flags_vertical = 4
 bbcode_enabled = true
 text = "GAME_STATISTIC"
 fit_content = true
 
-[node name="VBoxContainer2" type="HBoxContainer" parent="PanelContainer/MarginContainer/VBoxContainer/VBoxContainer2"]
+[node name="MarginContainer2" type="MarginContainer" parent="PanelContainer/MarginContainer/VBoxContainer2/BodyContainer/PanelContainer/VBoxContainer2/Header"]
+layout_mode = 2
+theme_override_constants/margin_left = 25
+theme_override_constants/margin_right = 25
+
+[node name="VBoxContainer2" type="HBoxContainer" parent="PanelContainer/MarginContainer/VBoxContainer2/BodyContainer/PanelContainer/VBoxContainer2/Header/MarginContainer2"]
 layout_mode = 2
 size_flags_vertical = 0
 
-[node name="PlayerNameTitle" type="RichTextLabel" parent="PanelContainer/MarginContainer/VBoxContainer/VBoxContainer2/VBoxContainer2"]
+[node name="PlayerNameTitle" type="RichTextLabel" parent="PanelContainer/MarginContainer/VBoxContainer2/BodyContainer/PanelContainer/VBoxContainer2/Header/MarginContainer2/VBoxContainer2"]
 layout_mode = 2
 size_flags_horizontal = 3
 text = "PLAYER_TITLE"
 fit_content = true
 
-[node name="PlayerScoreTitle" type="RichTextLabel" parent="PanelContainer/MarginContainer/VBoxContainer/VBoxContainer2/VBoxContainer2"]
+[node name="PlayerScoreTitle" type="RichTextLabel" parent="PanelContainer/MarginContainer/VBoxContainer2/BodyContainer/PanelContainer/VBoxContainer2/Header/MarginContainer2/VBoxContainer2"]
 layout_mode = 2
 size_flags_horizontal = 3
 bbcode_enabled = true
 text = "PLAYER_SCORE"
 
-[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer/MarginContainer/VBoxContainer/VBoxContainer2"]
+[node name="Player List" type="VBoxContainer" parent="PanelContainer/MarginContainer/VBoxContainer2/BodyContainer/PanelContainer/VBoxContainer2"]
 layout_mode = 2
-size_flags_vertical = 6
+size_flags_vertical = 3
 script = ExtResource("2_ohkho")
 player_template = ExtResource("3_6aww1")
 
-[node name="PlayerWon" type="HBoxContainer" parent="PanelContainer/MarginContainer/VBoxContainer/VBoxContainer2" node_paths=PackedStringArray("player_name_node")]
+[node name="Footer" type="MarginContainer" parent="PanelContainer/MarginContainer/VBoxContainer2"]
 layout_mode = 2
-script = ExtResource("2_wslvc")
-player_name_node = NodePath("WinningPlayer")
+size_flags_vertical = 3
+theme_override_constants/margin_top = 5
 
-[node name="PlayerWonText" type="RichTextLabel" parent="PanelContainer/MarginContainer/VBoxContainer/VBoxContainer2/PlayerWon"]
-layout_mode = 2
-size_flags_horizontal = 3
-text = "PLAYER_WON"
-fit_content = true
-
-[node name="WinningPlayer" type="RichTextLabel" parent="PanelContainer/MarginContainer/VBoxContainer/VBoxContainer2/PlayerWon"]
-layout_mode = 2
-size_flags_horizontal = 3
-text = "PLACEHOLDER"
-fit_content = true
-
-[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/MarginContainer/VBoxContainer"]
+[node name="Buttons" type="HBoxContainer" parent="PanelContainer/MarginContainer/VBoxContainer2/Footer"]
 layout_mode = 2
 size_flags_horizontal = 4
-size_flags_vertical = 10
+size_flags_vertical = 8
 
-[node name="OkButton" type="Button" parent="PanelContainer/MarginContainer/VBoxContainer/HBoxContainer"]
+[node name="OkButton" type="Button" parent="PanelContainer/MarginContainer/VBoxContainer2/Footer/Buttons"]
 layout_mode = 2
 size_flags_horizontal = 4
-size_flags_vertical = 4
+size_flags_vertical = 8
 text = "OK"
 script = ExtResource("5_8dsgm")
 is_focused = true
 
-[node name="ReplayGame" type="Button" parent="PanelContainer/MarginContainer/VBoxContainer/HBoxContainer" node_paths=PackedStringArray("finish_game_node")]
+[node name="ReplayGame" type="Button" parent="PanelContainer/MarginContainer/VBoxContainer2/Footer/Buttons" node_paths=PackedStringArray("finish_game_node")]
 layout_mode = 2
 text = "REPLAY"
 script = ExtResource("6_f0a12")
-finish_game_node = NodePath("../../../../..")
+finish_game_node = NodePath("../../../../../..")
 
-[connection signal="finish_game_ui_loaded" from="." to="PanelContainer/MarginContainer/VBoxContainer/VBoxContainer2/VBoxContainer" method="build_player_statistic"]
-[connection signal="finish_game_ui_loaded" from="." to="PanelContainer/MarginContainer/VBoxContainer/VBoxContainer2/PlayerWon" method="set_winning_players"]
+[connection signal="finish_game_ui_loaded" from="." to="PanelContainer/MarginContainer/VBoxContainer2/BodyContainer/PanelContainer/VBoxContainer2/Player List" method="build_player_statistic"]

--- a/scenes/game/overlay/PlayerNameOverlay.tscn
+++ b/scenes/game/overlay/PlayerNameOverlay.tscn
@@ -1,9 +1,13 @@
-[gd_scene load_steps=6 format=3 uid="uid://cynb8xjpxqa6w"]
+[gd_scene load_steps=12 format=3 uid="uid://cynb8xjpxqa6w"]
 
 [ext_resource type="Script" path="res://src/menu/PlayerGameLabel.gd" id="1_d33rg"]
 [ext_resource type="Texture2D" uid="uid://bmxqeqo65xwt" path="res://assets/sprites/spritesheet-default.png" id="2_blt2s"]
 [ext_resource type="Texture2D" uid="uid://lj7phnlllstw" path="res://assets/textures/HumanIcon.tres" id="2_urml8"]
 [ext_resource type="Texture2D" uid="uid://wa0qa5dgmjgk" path="res://assets/textures/AiIcon.tres" id="3_nldki"]
+[ext_resource type="Resource" uid="uid://c0eqsic62hvl0" path="res://scenes/menu/resources/colors/PlayerHighlightColor.tres" id="4_e0a06"]
+[ext_resource type="Shader" uid="uid://docbe2j6cd3wg" path="res://assets/shaders/ColorReplaceShader.tres" id="6_vrh8j"]
+[ext_resource type="Script" path="res://src/menu/ColorReplace.gd" id="7_4mda4"]
+[ext_resource type="Script" path="res://src/templates/ColorResource.gd" id="8_e0d5f"]
 
 [sub_resource type="StyleBoxTexture" id="StyleBoxTexture_qprtf"]
 texture = ExtResource("2_blt2s")
@@ -12,6 +16,14 @@ texture_margin_top = 16.0
 texture_margin_right = 16.0
 texture_margin_bottom = 16.0
 region_rect = Rect2(384, 384, 64, 64)
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_iisri"]
+shader = ExtResource("6_vrh8j")
+shader_parameter/replace_color = null
+
+[sub_resource type="Resource" id="Resource_u12w1"]
+script = ExtResource("8_e0d5f")
+color = Color(1, 1, 1, 1)
 
 [node name="MarginContainer" type="MarginContainer" node_paths=PackedStringArray("label", "player_type_icon_box")]
 anchors_preset = 15
@@ -29,6 +41,7 @@ label = NodePath("PanelContainer/HBoxContainer/RichTextLabel")
 player_type_icon_box = NodePath("PanelContainer/HBoxContainer/MarginContainer/TextureRect")
 human_player_icon = ExtResource("2_urml8")
 ai_player_icon = ExtResource("3_nldki")
+player_round_color = ExtResource("4_e0a06")
 
 [node name="PanelContainer" type="PanelContainer" parent="."]
 layout_mode = 2
@@ -56,6 +69,13 @@ theme_override_constants/margin_right = 3
 theme_override_constants/margin_bottom = 2
 
 [node name="TextureRect" type="TextureRect" parent="PanelContainer/HBoxContainer/MarginContainer"]
+material = SubResource("ShaderMaterial_iisri")
 layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 4
+script = ExtResource("7_4mda4")
+default_color = SubResource("Resource_u12w1")
+highlight_color = ExtResource("4_e0a06")
+
+[connection signal="player_is_active" from="." to="PanelContainer/HBoxContainer/MarginContainer/TextureRect" method="set_hightlight_color"]
+[connection signal="player_is_inactive" from="." to="PanelContainer/HBoxContainer/MarginContainer/TextureRect" method="set_default_color"]

--- a/scenes/game/overlay/PlayerScoreEntry.tscn
+++ b/scenes/game/overlay/PlayerScoreEntry.tscn
@@ -1,31 +1,54 @@
-[gd_scene load_steps=2 format=3 uid="uid://pwy03e08f1ov"]
+[gd_scene load_steps=7 format=3 uid="uid://pwy03e08f1ov"]
 
 [ext_resource type="Script" path="res://src/overlay/PlayerScoreEntry.gd" id="1_4epdj"]
+[ext_resource type="StyleBox" uid="uid://d1rhal5rp1608" path="res://assets/styles/MetalBox.tres" id="2_5y1a8"]
+[ext_resource type="Resource" uid="uid://c0eqsic62hvl0" path="res://scenes/menu/resources/colors/PlayerHighlightColor.tres" id="2_nkn6w"]
+[ext_resource type="Shader" uid="uid://docbe2j6cd3wg" path="res://assets/shaders/ColorReplaceShader.tres" id="4_4i8wl"]
+[ext_resource type="Texture2D" uid="uid://dpwyddj6yhp8r" path="res://assets/textures/TrophyIcon.tres" id="5_sqauh"]
 
-[node name="MarginContainer" type="MarginContainer" node_paths=PackedStringArray("player_name", "player_score")]
-anchors_preset = 15
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_uf65b"]
+shader = ExtResource("4_4i8wl")
+shader_parameter/replace_color = null
+
+[node name="MarginContainer" type="MarginContainer" node_paths=PackedStringArray("player_name", "player_score", "player_win_icon")]
+anchors_preset = 10
 anchor_right = 1.0
-anchor_bottom = 1.0
+offset_bottom = 75.0
 grow_horizontal = 2
-grow_vertical = 2
 theme_override_constants/margin_left = 10
-theme_override_constants/margin_top = 10
+theme_override_constants/margin_top = 5
 theme_override_constants/margin_right = 10
-theme_override_constants/margin_bottom = 10
+theme_override_constants/margin_bottom = 0
 script = ExtResource("1_4epdj")
-player_name = NodePath("HBoxContainer/PlayerName")
-player_score = NodePath("HBoxContainer/PlayerScore")
+player_name = NodePath("PanelContainer/HBoxContainer/PlayerName")
+player_score = NodePath("PanelContainer/HBoxContainer/PlayerScore")
+player_win_icon = NodePath("PanelContainer/HBoxContainer/MarginContainer/TextureRect")
+player_win_color = ExtResource("2_nkn6w")
 
-[node name="HBoxContainer" type="HBoxContainer" parent="."]
+[node name="PanelContainer" type="PanelContainer" parent="."]
+layout_mode = 2
+theme_override_styles/panel = ExtResource("2_5y1a8")
+
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer"]
 layout_mode = 2
 
-[node name="PlayerName" type="RichTextLabel" parent="HBoxContainer"]
+[node name="PlayerName" type="Label" parent="PanelContainer/HBoxContainer"]
 layout_mode = 2
-size_flags_horizontal = 3
 text = "PLAYER_NAME"
-fit_content = true
 
-[node name="PlayerScore" type="RichTextLabel" parent="HBoxContainer"]
+[node name="MarginContainer" type="MarginContainer" parent="PanelContainer/HBoxContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 20
+
+[node name="TextureRect" type="TextureRect" parent="PanelContainer/HBoxContainer/MarginContainer"]
+material = SubResource("ShaderMaterial_uf65b")
+layout_mode = 2
+size_flags_horizontal = 4
+size_flags_vertical = 4
+texture = ExtResource("5_sqauh")
+stretch_mode = 3
+
+[node name="PlayerScore" type="RichTextLabel" parent="PanelContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 bbcode_enabled = true

--- a/scenes/menu/resources/colors/PlayerHighlightColor.tres
+++ b/scenes/menu/resources/colors/PlayerHighlightColor.tres
@@ -1,0 +1,7 @@
+[gd_resource type="Resource" script_class="ColorResource" load_steps=2 format=3 uid="uid://c0eqsic62hvl0"]
+
+[ext_resource type="Script" path="res://src/templates/ColorResource.gd" id="1_hr4rv"]
+
+[resource]
+script = ExtResource("1_hr4rv")
+color = Color(0.172549, 0.203922, 0.231373, 1)

--- a/src/menu/ColorReplace.gd
+++ b/src/menu/ColorReplace.gd
@@ -1,0 +1,28 @@
+extends TextureRect
+
+@export var default_color: ColorResource
+@export var highlight_color: ColorResource
+
+var active: bool = false
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	if material is ShaderMaterial:
+		material = material.duplicate()
+		active = true
+		set_color(default_color.get_color())
+		return
+
+func set_default_color():
+	if !active:
+		return
+	set_color(default_color.get_color())
+
+func set_hightlight_color():
+	if !active:
+		return
+	set_color(highlight_color.get_color())
+
+func set_color(color: Color):
+	var color_vector: Vector3 = Vector3(color.r, color.g, color.b)
+	material.set_shader_parameter("replace_color", color_vector)

--- a/src/menu/PlayerCard.gd
+++ b/src/menu/PlayerCard.gd
@@ -17,10 +17,7 @@ signal regain_focus_request()
 var delete_queued: bool = false
 
 func _ready():
-	var name_suffix = ""
-	if  player_card.is_ai():
-		name_suffix = " [AI]"
-	player_name_field.text = player_card.name + name_suffix
+	player_name_field.text = player_card.get_display_name()
 	var icon = human_player_icon
 	if player_card.is_ai():
 		icon = ai_player_icon

--- a/src/menu/PlayerGameLabel.gd
+++ b/src/menu/PlayerGameLabel.gd
@@ -1,11 +1,15 @@
 extends MarginContainer
 
-class_name  PlayerGameLabel
+class_name PlayerGameLabel
+
+signal player_is_active()
+signal player_is_inactive()
 
 @export var label: RichTextLabel
 @export var player_type_icon_box: TextureRect
 @export var human_player_icon: Texture
 @export var ai_player_icon: Texture
+@export var player_round_color: ColorResource
 
 var active_id: int = -1
 var contained_player: PlayerResource
@@ -34,15 +38,16 @@ func player_scored(player_id: int, score: int):
 	set_player_name()
 
 func build_player_name() -> String:
-	var return_name = contained_player.name
-	if contained_player.is_ai():
-		return_name = return_name + " [AI]"
+	var return_name = contained_player.get_display_name()
 	return return_name + " (" + str(player_score) + ")"
 
 func set_player_name():
 	label.text = build_player_name()
 	if contained_player.id == active_id:
-		label.text = "[color=red]" + build_player_name() + "[/color]"
+		label.text = player_round_color.get_color_bb_code() + build_player_name() + "[/color]"
+		player_is_active.emit()
+	else:
+		player_is_inactive.emit()
 
 func round_end():
 	set_player_name()

--- a/src/overlay/GameFinished.gd
+++ b/src/overlay/GameFinished.gd
@@ -7,7 +7,10 @@ var played_deck: MemoryDeckResource
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	var players = manager.get_players()
+	var players: Array[PlayerResource] = []
+	if manager != null:
+		players = manager.get_players()
+		
 	var highest_score = -1
 	for player in players:
 		if player.score >= highest_score:

--- a/src/overlay/PlayerScoreEntry.gd
+++ b/src/overlay/PlayerScoreEntry.gd
@@ -2,17 +2,21 @@ extends Control
 
 class_name PlayerScoreEntry
 
-@export var player_name: RichTextLabel
+@export var player_name: Label
 @export var player_score: RichTextLabel
+@export var player_win_icon: TextureRect
+@export var player_win_color: ColorResource
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	player_name.bbcode_enabled = true
+	#player_name.bbcode_enabled = true
 	player_score.bbcode_enabled = true
 
 func set_player(player: PlayerResource, did_win: bool):
-	player_name.text = player.name
+	player_win_icon.visible = did_win
+	player_name.text = player.get_display_name()
 	player_score.text = "[right]" + str(player.score) + "[/right]"
 	if did_win:
-		player_name.text = "[color=red]" + player_name.text + "[/color]"
-		player_score.text = "[right][color=red]" + str(player.score) + "[/color][/right]"
+		player_name.set("theme_override_colors/font_color",player_win_color.get_color())
+		player_name.text = player_name.text
+		player_score.text = "[right]" + player_win_color.get_color_bb_code() + str(player.score) + "[/color][/right]"

--- a/src/templates/ColorResource.gd
+++ b/src/templates/ColorResource.gd
@@ -1,0 +1,10 @@
+
+class_name ColorResource extends Resource
+
+@export_color_no_alpha var color: Color
+
+func get_color() -> Color:
+	return color
+
+func get_color_bb_code() -> String:
+	return "[color=#" + get_color().to_html() + "]"

--- a/src/templates/PlayerResource.gd
+++ b/src/templates/PlayerResource.gd
@@ -7,5 +7,10 @@ extends Resource
 @export var order_number: int
 @export var id: int
 
+func get_display_name():
+    if is_ai():
+        return name + " [AI]"
+    return name
+
 func is_ai() -> bool:
     return ai_difficulty != null


### PR DESCRIPTION
Improve the visuals apperance of the game end screen. Add a new resource containing a color only, this does make sure that the same highlight color is used for all the highlighted labels. Add a new shader to change the color of a sprite, this is required to recolor the game icons.
Add color to player or ai icon if it is the player turn. Add a new trophy icon to the game end screen to reward players with.