### PR TITLE
[FEATURE] change build pipeline to godot ci

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -4,27 +4,40 @@ on:
   pull_request:
     branches: [ "main", "develop" ]
 
+env:
+  GODOT_VERSION: 4.3
+  PROJECT_PATH: .
+
 jobs:
   Check-Build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         platform:
-        - name: linux
-          file: samory
+        - name: windows
+          preset: windows
+          os: windows
+          file: samory.exe
+    container:
+      image: barichello/godot-ci:4.3
     steps:
       - uses: actions/checkout@v3
         with:
            lfs: true
-      - name: Build
-        id: build
-        uses: manleydev/build-godot-action@master
-        with:
-          name: ${{ matrix.platform.file }}
-          preset: ${{ matrix.platform.name }}
-          debugMode: "true"
+      - name: Setup
+        run: |
+          mkdir -v -p ~/.local/share/godot/export_templates/
+          mkdir -v -p ~/.config/
+          mv /root/.config/godot ~/.config/godot
+          mv /root/.local/share/godot/export_templates/${GODOT_VERSION}.stable ~/.local/share/godot/export_templates/${GODOT_VERSION}.stable
+      - name: Build ${{ matrix.platform.name }}
+        run: |
+          mkdir -v -p build/${{ matrix.platform.os }}
+          EXPORT_DIR="$(readlink -f build)"
+          cd $PROJECT_PATH
+          godot --headless --verbose --export-debug ${{ matrix.platform.preset }} "$EXPORT_DIR/${{ matrix.platform.os }}/${{ matrix.platform.file }}"
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
           name: Samory - ${{ matrix.platform.name }}
-          path: ${{ github.workspace }}/${{ steps.build.outputs.build }}
+          path: build/${{ matrix.platform.os }}

--- a/.github/workflows/create-live-build.yml
+++ b/.github/workflows/create-live-build.yml
@@ -7,6 +7,8 @@ on:
 env:
   REF_CHECKOUT_BRANCH: main
   RELEASE_ARTIFACT_FOLDER: artifacts
+  GODOT_VERSION: 4.3
+  PROJECT_PATH: .
   DEBUG: false
 
 jobs:
@@ -31,30 +33,42 @@ jobs:
          fi
   build:
     name: Build Samory
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: ["build-version"]
     strategy:
       matrix:
         platform:
         - name: linux
+          preset: linux
+          os: linux
           file: samory
         - name: windows
+          preset: windows
+          os: windows
           file: samory.exe
+    container:
+      image: barichello/godot-ci:4.3
     steps:
       - uses: actions/checkout@v3
         with:
            lfs: true
-      - name: Build
-        id: build
-        uses: manleydev/build-godot-action@master
-        with:
-          name: ${{ matrix.platform.file }}
-          preset: ${{ matrix.platform.name }}
+      - name: Setup
+        run: |
+          mkdir -v -p ~/.local/share/godot/export_templates/
+          mkdir -v -p ~/.config/
+          mv /root/.config/godot ~/.config/godot
+          mv /root/.local/share/godot/export_templates/${GODOT_VERSION}.stable ~/.local/share/godot/export_templates/${GODOT_VERSION}.stable
+      - name: Build ${{ matrix.platform.name }}
+        run: |
+          mkdir -v -p build/${{ matrix.platform.os }}
+          EXPORT_DIR="$(readlink -f build)"
+          cd $PROJECT_PATH
+          godot --headless --verbose --export-release ${{ matrix.platform.preset }} "$EXPORT_DIR/${{ matrix.platform.os }}/${{ matrix.platform.file }}"
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
           name: Samory_${{ needs.build-version.outputs.build-version }}-${{ matrix.platform.name }}
-          path: ${{ github.workspace }}/${{ steps.build.outputs.build }}
+          path: build/${{ matrix.platform.os }}
   upload-release:
     name: Upload Artifacts to GitHub Release
     runs-on: ubuntu-latest


### PR DESCRIPTION
This change does use the godot headless tool for project build, this does make the building a more complicated but much more flexible and up to date.