### PR TITLE
fix: replace svg spritesheet with png

### DIFF
--- a/assets/sprites/genericItems_spritesheet_colored.png
+++ b/assets/sprites/genericItems_spritesheet_colored.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4656d0c11ed3f7b9631511102d07d40e40ebb8672500a9dcdfb693527454963e
+size 317435

--- a/assets/sprites/genericItems_spritesheet_colored.png.import
+++ b/assets/sprites/genericItems_spritesheet_colored.png.import
@@ -2,16 +2,16 @@
 
 importer="texture"
 type="CompressedTexture2D"
-uid="uid://cjf0iw8w4drb7"
-path="res://.godot/imported/genericItems_vector_colored.svg-3677ade6cff7fcbe4fee822261f607dd.ctex"
+uid="uid://dv4h5xis22ax1"
+path="res://.godot/imported/genericItems_spritesheet_colored.png-3e78ebff3de59eeec06454d0876b69c5.ctex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://assets/sprites/genericItems_vector_colored.svg"
-dest_files=["res://.godot/imported/genericItems_vector_colored.svg-3677ade6cff7fcbe4fee822261f607dd.ctex"]
+source_file="res://assets/sprites/genericItems_spritesheet_colored.png"
+dest_files=["res://.godot/imported/genericItems_spritesheet_colored.png-3e78ebff3de59eeec06454d0876b69c5.ctex"]
 
 [params]
 
@@ -32,6 +32,3 @@ process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
-svg/scale=5.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false

--- a/assets/sprites/genericItems_vector_colored.svg
+++ b/assets/sprites/genericItems_vector_colored.svg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bcc8ca519b57c88f25e2348157161597e61e74637a89d9a9bbd83fa751be67aa
-size 126187

--- a/scenes/game/resources/cards/generic_items/BriefcaseCard.tres
+++ b/scenes/game/resources/cards/generic_items/BriefcaseCard.tres
@@ -1,11 +1,11 @@
 [gd_resource type="Resource" script_class="MemoryCardResource" load_steps=4 format=3 uid="uid://t0i7bis7c8jm"]
 
 [ext_resource type="Script" uid="uid://d3u4837pgjc3d" path="res://src/templates/MemoryCardResource.gd" id="1_lq32d"]
-[ext_resource type="Texture2D" uid="uid://cjf0iw8w4drb7" path="res://assets/sprites/genericItems_vector_colored.svg" id="2_twvgr"]
+[ext_resource type="Texture2D" uid="uid://dv4h5xis22ax1" path="res://assets/sprites/genericItems_spritesheet_colored.png" id="2_wls20"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_ntfws"]
-atlas = ExtResource("2_twvgr")
-region = Rect2(17, 2599, 293, 273)
+atlas = ExtResource("2_wls20")
+region = Rect2(141, 1115, 121, 117)
 
 [resource]
 script = ExtResource("1_lq32d")

--- a/scenes/game/resources/cards/generic_items/BrushCard.tres
+++ b/scenes/game/resources/cards/generic_items/BrushCard.tres
@@ -1,14 +1,14 @@
 [gd_resource type="Resource" script_class="MemoryCardResource" load_steps=4 format=3 uid="uid://b8jo5vna4u8r6"]
 
 [ext_resource type="Script" uid="uid://d3u4837pgjc3d" path="res://src/templates/MemoryCardResource.gd" id="1_y1wdi"]
-[ext_resource type="Texture2D" uid="uid://cjf0iw8w4drb7" path="res://assets/sprites/genericItems_vector_colored.svg" id="2_7v20h"]
+[ext_resource type="Texture2D" uid="uid://dv4h5xis22ax1" path="res://assets/sprites/genericItems_spritesheet_colored.png" id="2_q26j0"]
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_80we1"]
-atlas = ExtResource("2_7v20h")
-region = Rect2(557, 526, 125, 223)
+[sub_resource type="AtlasTexture" id="AtlasTexture_u3htl"]
+atlas = ExtResource("2_q26j0")
+region = Rect2(690, 1470, 54, 98)
 
 [resource]
 script = ExtResource("1_y1wdi")
 name = "BRUSH"
 description = "BRUSH_DESCRIPTION"
-texture = SubResource("AtlasTexture_80we1")
+texture = SubResource("AtlasTexture_u3htl")

--- a/scenes/game/resources/cards/generic_items/CameraCard.tres
+++ b/scenes/game/resources/cards/generic_items/CameraCard.tres
@@ -1,11 +1,11 @@
 [gd_resource type="Resource" script_class="MemoryCardResource" load_steps=4 format=3 uid="uid://bskgl050rc3rn"]
 
 [ext_resource type="Script" uid="uid://d3u4837pgjc3d" path="res://src/templates/MemoryCardResource.gd" id="1_v7abh"]
-[ext_resource type="Texture2D" uid="uid://cjf0iw8w4drb7" path="res://assets/sprites/genericItems_vector_colored.svg" id="2_h0onm"]
+[ext_resource type="Texture2D" uid="uid://dv4h5xis22ax1" path="res://assets/sprites/genericItems_spritesheet_colored.png" id="2_xpo00"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_bjhwo"]
-atlas = ExtResource("2_h0onm")
-region = Rect2(1612, 924, 381, 220)
+atlas = ExtResource("2_xpo00")
+region = Rect2(0, 532, 152, 88)
 
 [resource]
 script = ExtResource("1_v7abh")

--- a/scenes/game/resources/cards/generic_items/CdCard.tres
+++ b/scenes/game/resources/cards/generic_items/CdCard.tres
@@ -1,11 +1,11 @@
 [gd_resource type="Resource" script_class="MemoryCardResource" load_steps=4 format=3 uid="uid://ckk2d27jq2hcu"]
 
 [ext_resource type="Script" uid="uid://d3u4837pgjc3d" path="res://src/templates/MemoryCardResource.gd" id="1_odwjo"]
-[ext_resource type="Texture2D" uid="uid://cjf0iw8w4drb7" path="res://assets/sprites/genericItems_vector_colored.svg" id="2_fuo4k"]
+[ext_resource type="Texture2D" uid="uid://dv4h5xis22ax1" path="res://assets/sprites/genericItems_spritesheet_colored.png" id="2_6cysh"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_fo2dy"]
-atlas = ExtResource("2_fuo4k")
-region = Rect2(5966, 1270, 204, 203)
+atlas = ExtResource("2_6cysh")
+region = Rect2(550, 875, 82, 81)
 
 [resource]
 script = ExtResource("1_odwjo")

--- a/scenes/game/resources/cards/generic_items/ComputerCard.tres
+++ b/scenes/game/resources/cards/generic_items/ComputerCard.tres
@@ -1,11 +1,11 @@
 [gd_resource type="Resource" script_class="MemoryCardResource" load_steps=4 format=3 uid="uid://bi07necohgv76"]
 
 [ext_resource type="Script" uid="uid://d3u4837pgjc3d" path="res://src/templates/MemoryCardResource.gd" id="1_n44cl"]
-[ext_resource type="Texture2D" uid="uid://cjf0iw8w4drb7" path="res://assets/sprites/genericItems_vector_colored.svg" id="2_3kaso"]
+[ext_resource type="Texture2D" uid="uid://dv4h5xis22ax1" path="res://assets/sprites/genericItems_spritesheet_colored.png" id="2_a0c6v"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_rggij"]
-atlas = ExtResource("2_3kaso")
-region = Rect2(4751, 873, 243, 321)
+atlas = ExtResource("2_a0c6v")
+region = Rect2(364, 1328, 97, 130)
 
 [resource]
 script = ExtResource("1_n44cl")

--- a/scenes/game/resources/cards/generic_items/HeadphoneCard.tres
+++ b/scenes/game/resources/cards/generic_items/HeadphoneCard.tres
@@ -1,11 +1,11 @@
 [gd_resource type="Resource" script_class="MemoryCardResource" load_steps=4 format=3 uid="uid://qmm6cy0vyfhx"]
 
 [ext_resource type="Script" uid="uid://d3u4837pgjc3d" path="res://src/templates/MemoryCardResource.gd" id="1_c4h5m"]
-[ext_resource type="Texture2D" uid="uid://cjf0iw8w4drb7" path="res://assets/sprites/genericItems_vector_colored.svg" id="2_jwvjg"]
+[ext_resource type="Texture2D" uid="uid://dv4h5xis22ax1" path="res://assets/sprites/genericItems_spritesheet_colored.png" id="2_qc45b"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_3l33r"]
-atlas = ExtResource("2_jwvjg")
-region = Rect2(5627, 1227, 262, 293)
+atlas = ExtResource("2_qc45b")
+region = Rect2(257, 1331, 106, 118)
 
 [resource]
 script = ExtResource("1_c4h5m")

--- a/scenes/game/resources/cards/generic_items/MicrophoneCard.tres
+++ b/scenes/game/resources/cards/generic_items/MicrophoneCard.tres
@@ -1,11 +1,11 @@
 [gd_resource type="Resource" script_class="MemoryCardResource" load_steps=4 format=3 uid="uid://bx8upxfh0e0jg"]
 
 [ext_resource type="Script" uid="uid://d3u4837pgjc3d" path="res://src/templates/MemoryCardResource.gd" id="1_2lpg1"]
-[ext_resource type="Texture2D" uid="uid://cjf0iw8w4drb7" path="res://assets/sprites/genericItems_vector_colored.svg" id="2_wua6x"]
+[ext_resource type="Texture2D" uid="uid://dv4h5xis22ax1" path="res://assets/sprites/genericItems_spritesheet_colored.png" id="2_pfoqu"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_spcrc"]
-atlas = ExtResource("2_wua6x")
-region = Rect2(5407, 1255, 145, 287)
+atlas = ExtResource("2_pfoqu")
+region = Rect2(632, 696, 58, 116)
 
 [resource]
 script = ExtResource("1_2lpg1")

--- a/scenes/game/resources/cards/generic_items/MicroscopeCard.tres
+++ b/scenes/game/resources/cards/generic_items/MicroscopeCard.tres
@@ -1,11 +1,11 @@
 [gd_resource type="Resource" script_class="MemoryCardResource" load_steps=4 format=3 uid="uid://uh4xlrleuvqs"]
 
 [ext_resource type="Script" uid="uid://d3u4837pgjc3d" path="res://src/templates/MemoryCardResource.gd" id="1_v6pba"]
-[ext_resource type="Texture2D" uid="uid://cjf0iw8w4drb7" path="res://assets/sprites/genericItems_vector_colored.svg" id="2_p86ab"]
+[ext_resource type="Texture2D" uid="uid://dv4h5xis22ax1" path="res://assets/sprites/genericItems_spritesheet_colored.png" id="2_0lsno"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_2l56x"]
-atlas = ExtResource("2_p86ab")
-region = Rect2(3347, 1611, 276, 346)
+atlas = ExtResource("2_0lsno")
+region = Rect2(254, 1804, 110, 138)
 
 [resource]
 script = ExtResource("1_v6pba")

--- a/scenes/game/resources/cards/generic_items/ModernControllerCard.tres
+++ b/scenes/game/resources/cards/generic_items/ModernControllerCard.tres
@@ -1,11 +1,11 @@
 [gd_resource type="Resource" script_class="MemoryCardResource" load_steps=4 format=3 uid="uid://bqm3vhwb85p7m"]
 
 [ext_resource type="Script" uid="uid://d3u4837pgjc3d" path="res://src/templates/MemoryCardResource.gd" id="1_ewnn0"]
-[ext_resource type="Texture2D" uid="uid://cjf0iw8w4drb7" path="res://assets/sprites/genericItems_vector_colored.svg" id="2_r8idp"]
+[ext_resource type="Texture2D" uid="uid://dv4h5xis22ax1" path="res://assets/sprites/genericItems_spritesheet_colored.png" id="2_ay65r"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_ybmuq"]
-atlas = ExtResource("2_r8idp")
-region = Rect2(5107, 1306, 241, 156)
+atlas = ExtResource("2_ay65r")
+region = Rect2(248, 1448, 115, 66)
 
 [resource]
 script = ExtResource("1_ewnn0")

--- a/scenes/game/resources/cards/generic_items/MoneyCard.tres
+++ b/scenes/game/resources/cards/generic_items/MoneyCard.tres
@@ -1,11 +1,11 @@
 [gd_resource type="Resource" script_class="MemoryCardResource" load_steps=4 format=3 uid="uid://chxne0udrs8jr"]
 
 [ext_resource type="Script" uid="uid://d3u4837pgjc3d" path="res://src/templates/MemoryCardResource.gd" id="1_aimq0"]
-[ext_resource type="Texture2D" uid="uid://cjf0iw8w4drb7" path="res://assets/sprites/genericItems_vector_colored.svg" id="2_rmnxx"]
+[ext_resource type="Texture2D" uid="uid://dv4h5xis22ax1" path="res://assets/sprites/genericItems_spritesheet_colored.png" id="2_ubrjw"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_i4axf"]
-atlas = ExtResource("2_rmnxx")
-region = Rect2(5496, 2603, 252, 262)
+atlas = ExtResource("2_ubrjw")
+region = Rect2(268, 650, 101, 105)
 
 [resource]
 script = ExtResource("1_aimq0")

--- a/scenes/game/resources/cards/generic_items/MortarAndPestleCard.tres
+++ b/scenes/game/resources/cards/generic_items/MortarAndPestleCard.tres
@@ -1,11 +1,11 @@
 [gd_resource type="Resource" script_class="MemoryCardResource" load_steps=4 format=3 uid="uid://oxrnjtqftays"]
 
 [ext_resource type="Script" uid="uid://d3u4837pgjc3d" path="res://src/templates/MemoryCardResource.gd" id="1_qb6vo"]
-[ext_resource type="Texture2D" uid="uid://cjf0iw8w4drb7" path="res://assets/sprites/genericItems_vector_colored.svg" id="2_u75ok"]
+[ext_resource type="Texture2D" uid="uid://dv4h5xis22ax1" path="res://assets/sprites/genericItems_spritesheet_colored.png" id="2_iftro"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_d4i5c"]
-atlas = ExtResource("2_u75ok")
-region = Rect2(3724, 1550, 239, 424)
+atlas = ExtResource("2_iftro")
+region = Rect2(464, 696, 86, 88)
 
 [resource]
 script = ExtResource("1_qb6vo")

--- a/scenes/game/resources/cards/generic_items/NotebookCard.tres
+++ b/scenes/game/resources/cards/generic_items/NotebookCard.tres
@@ -1,11 +1,11 @@
 [gd_resource type="Resource" script_class="MemoryCardResource" load_steps=4 format=3 uid="uid://cj6x44b6htab5"]
 
 [ext_resource type="Script" uid="uid://d3u4837pgjc3d" path="res://src/templates/MemoryCardResource.gd" id="1_u1bd2"]
-[ext_resource type="Texture2D" uid="uid://cjf0iw8w4drb7" path="res://assets/sprites/genericItems_vector_colored.svg" id="2_bceb5"]
+[ext_resource type="Texture2D" uid="uid://dv4h5xis22ax1" path="res://assets/sprites/genericItems_spritesheet_colored.png" id="2_a87p5"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_6r22x"]
-atlas = ExtResource("2_bceb5")
-region = Rect2(3144, 865, 356, 338)
+atlas = ExtResource("2_a87p5")
+region = Rect2(0, 1027, 143, 136)
 
 [resource]
 script = ExtResource("1_u1bd2")

--- a/scenes/game/resources/cards/generic_items/PanCard.tres
+++ b/scenes/game/resources/cards/generic_items/PanCard.tres
@@ -1,11 +1,11 @@
 [gd_resource type="Resource" script_class="MemoryCardResource" load_steps=4 format=3 uid="uid://kcssx3ss1hyc"]
 
 [ext_resource type="Script" uid="uid://d3u4837pgjc3d" path="res://src/templates/MemoryCardResource.gd" id="1_c4ier"]
-[ext_resource type="Texture2D" uid="uid://cjf0iw8w4drb7" path="res://assets/sprites/genericItems_vector_colored.svg" id="2_u0oxr"]
+[ext_resource type="Texture2D" uid="uid://dv4h5xis22ax1" path="res://assets/sprites/genericItems_spritesheet_colored.png" id="2_4xlxp"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_yk2yj"]
-atlas = ExtResource("2_u0oxr")
-region = Rect2(628, 2027, 236, 380)
+atlas = ExtResource("2_4xlxp")
+region = Rect2(369, 623, 95, 161)
 
 [resource]
 script = ExtResource("1_c4ier")

--- a/scenes/game/resources/cards/generic_items/PhoneCard.tres
+++ b/scenes/game/resources/cards/generic_items/PhoneCard.tres
@@ -1,11 +1,11 @@
 [gd_resource type="Resource" script_class="MemoryCardResource" load_steps=4 format=3 uid="uid://bn83vd52k12bk"]
 
 [ext_resource type="Script" uid="uid://d3u4837pgjc3d" path="res://src/templates/MemoryCardResource.gd" id="1_eqmuh"]
-[ext_resource type="Texture2D" uid="uid://cjf0iw8w4drb7" path="res://assets/sprites/genericItems_vector_colored.svg" id="2_vihdb"]
+[ext_resource type="Texture2D" uid="uid://dv4h5xis22ax1" path="res://assets/sprites/genericItems_spritesheet_colored.png" id="2_ac0c1"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_hmyii"]
-atlas = ExtResource("2_vihdb")
-region = Rect2(937, 1281, 161, 206)
+atlas = ExtResource("2_ac0c1")
+region = Rect2(475, 0, 83, 98)
 
 [resource]
 script = ExtResource("1_eqmuh")

--- a/scenes/game/resources/cards/generic_items/PickaxeCard.tres
+++ b/scenes/game/resources/cards/generic_items/PickaxeCard.tres
@@ -1,11 +1,11 @@
 [gd_resource type="Resource" script_class="MemoryCardResource" load_steps=4 format=3 uid="uid://djbvm828hnwc0"]
 
 [ext_resource type="Script" uid="uid://d3u4837pgjc3d" path="res://src/templates/MemoryCardResource.gd" id="1_6xi6f"]
-[ext_resource type="Texture2D" uid="uid://cjf0iw8w4drb7" path="res://assets/sprites/genericItems_vector_colored.svg" id="2_jopqt"]
+[ext_resource type="Texture2D" uid="uid://dv4h5xis22ax1" path="res://assets/sprites/genericItems_spritesheet_colored.png" id="2_kju2d"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_wxqxe"]
-atlas = ExtResource("2_jopqt")
-region = Rect2(5171, 43, 306, 384)
+atlas = ExtResource("2_kju2d")
+region = Rect2(134, 1360, 123, 155)
 
 [resource]
 script = ExtResource("1_6xi6f")

--- a/scenes/game/resources/cards/generic_items/PotCard.tres
+++ b/scenes/game/resources/cards/generic_items/PotCard.tres
@@ -1,11 +1,11 @@
 [gd_resource type="Resource" script_class="MemoryCardResource" load_steps=4 format=3 uid="uid://csd56njbfcl77"]
 
 [ext_resource type="Script" uid="uid://d3u4837pgjc3d" path="res://src/templates/MemoryCardResource.gd" id="1_c21rq"]
-[ext_resource type="Texture2D" uid="uid://cjf0iw8w4drb7" path="res://assets/sprites/genericItems_vector_colored.svg" id="2_hr1t8"]
+[ext_resource type="Texture2D" uid="uid://dv4h5xis22ax1" path="res://assets/sprites/genericItems_spritesheet_colored.png" id="2_w0mcr"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_4a65t"]
-atlas = ExtResource("2_hr1t8")
-region = Rect2(0, 2104, 364, 260)
+atlas = ExtResource("2_w0mcr")
+region = Rect2(0, 776, 146, 104)
 
 [resource]
 script = ExtResource("1_c21rq")

--- a/scenes/game/resources/cards/generic_items/SawCard.tres
+++ b/scenes/game/resources/cards/generic_items/SawCard.tres
@@ -1,11 +1,11 @@
 [gd_resource type="Resource" script_class="MemoryCardResource" load_steps=4 format=3 uid="uid://cvulxb1epwmdw"]
 
 [ext_resource type="Script" uid="uid://d3u4837pgjc3d" path="res://src/templates/MemoryCardResource.gd" id="1_63nnx"]
-[ext_resource type="Texture2D" uid="uid://cjf0iw8w4drb7" path="res://assets/sprites/genericItems_vector_colored.svg" id="2_gqfdw"]
+[ext_resource type="Texture2D" uid="uid://dv4h5xis22ax1" path="res://assets/sprites/genericItems_spritesheet_colored.png" id="2_6xn8w"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_35143"]
-atlas = ExtResource("2_gqfdw")
-region = Rect2(3953, 0, 258, 467)
+atlas = ExtResource("2_6xn8w")
+region = Rect2(276, 88, 106, 190)
 
 [resource]
 script = ExtResource("1_63nnx")

--- a/scenes/game/resources/cards/generic_items/ShovleCard.tres
+++ b/scenes/game/resources/cards/generic_items/ShovleCard.tres
@@ -1,11 +1,11 @@
 [gd_resource type="Resource" script_class="MemoryCardResource" load_steps=4 format=3 uid="uid://cqif8a425crwn"]
 
 [ext_resource type="Script" uid="uid://d3u4837pgjc3d" path="res://src/templates/MemoryCardResource.gd" id="1_8baqe"]
-[ext_resource type="Texture2D" uid="uid://cjf0iw8w4drb7" path="res://assets/sprites/genericItems_vector_colored.svg" id="2_y65vh"]
+[ext_resource type="Texture2D" uid="uid://dv4h5xis22ax1" path="res://assets/sprites/genericItems_spritesheet_colored.png" id="2_linr0"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_l5gxe"]
-atlas = ExtResource("2_y65vh")
-region = Rect2(5510, 41, 215, 405)
+atlas = ExtResource("2_linr0")
+region = Rect2(465, 534, 86, 162)
 
 [resource]
 script = ExtResource("1_8baqe")

--- a/scenes/game/resources/cards/generic_items/SledgehammerCard.tres
+++ b/scenes/game/resources/cards/generic_items/SledgehammerCard.tres
@@ -1,11 +1,11 @@
 [gd_resource type="Resource" script_class="MemoryCardResource" load_steps=4 format=3 uid="uid://r4714ni4lm22"]
 
 [ext_resource type="Script" uid="uid://d3u4837pgjc3d" path="res://src/templates/MemoryCardResource.gd" id="1_6ckta"]
-[ext_resource type="Texture2D" uid="uid://cjf0iw8w4drb7" path="res://assets/sprites/genericItems_vector_colored.svg" id="2_yxrbf"]
+[ext_resource type="Texture2D" uid="uid://dv4h5xis22ax1" path="res://assets/sprites/genericItems_spritesheet_colored.png" id="2_q8fch"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_0v12h"]
-atlas = ExtResource("2_yxrbf")
-region = Rect2(5809, 6, 259, 440)
+atlas = ExtResource("2_q8fch")
+region = Rect2(270, 456, 103, 176)
 
 [resource]
 script = ExtResource("1_6ckta")

--- a/scenes/game/resources/cards/generic_items/TeaPotCard.tres
+++ b/scenes/game/resources/cards/generic_items/TeaPotCard.tres
@@ -1,11 +1,11 @@
 [gd_resource type="Resource" script_class="MemoryCardResource" load_steps=4 format=3 uid="uid://cd0pqakylhtxh"]
 
 [ext_resource type="Script" uid="uid://d3u4837pgjc3d" path="res://src/templates/MemoryCardResource.gd" id="1_6mmpx"]
-[ext_resource type="Texture2D" uid="uid://cjf0iw8w4drb7" path="res://assets/sprites/genericItems_vector_colored.svg" id="2_a74cl"]
+[ext_resource type="Texture2D" uid="uid://dv4h5xis22ax1" path="res://assets/sprites/genericItems_spritesheet_colored.png" id="2_m0s8m"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_ij28r"]
-atlas = ExtResource("2_a74cl")
-region = Rect2(2843, 2058, 380, 287)
+atlas = ExtResource("2_m0s8m")
+region = Rect2(0, 620, 152, 116)
 
 [resource]
 script = ExtResource("1_6mmpx")

--- a/scenes/game/resources/cards/generic_items/ThoothbrushCard.tres
+++ b/scenes/game/resources/cards/generic_items/ThoothbrushCard.tres
@@ -1,11 +1,11 @@
 [gd_resource type="Resource" script_class="MemoryCardResource" load_steps=4 format=3 uid="uid://si3w4ut4o3lb"]
 
 [ext_resource type="Script" uid="uid://d3u4837pgjc3d" path="res://src/templates/MemoryCardResource.gd" id="1_qynpn"]
-[ext_resource type="Texture2D" uid="uid://cjf0iw8w4drb7" path="res://assets/sprites/genericItems_vector_colored.svg" id="2_wc6pi"]
+[ext_resource type="Texture2D" uid="uid://dv4h5xis22ax1" path="res://assets/sprites/genericItems_spritesheet_colored.png" id="2_fl5v1"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_p3txb"]
-atlas = ExtResource("2_wc6pi")
-region = Rect2(366, 1648, 183, 264)
+atlas = ExtResource("2_fl5v1")
+region = Rect2(551, 506, 74, 107)
 
 [resource]
 script = ExtResource("1_qynpn")


### PR DESCRIPTION
There was an issue with the chrome browser on Android which did no properly display the svg sprite atlas textures. To solve this issue the svg was replaced with an png. This whole situation is very likely a result of the svg file being super large.