### PR TITLE
feat: add missing transitions

### DIFF
--- a/scenes/game/levels/LoadingScreen.tscn
+++ b/scenes/game/levels/LoadingScreen.tscn
@@ -15,13 +15,14 @@ point_count = 2
 
 [node name="LoadingScreen" type="Node2D" node_paths=PackedStringArray("screen_message", "static_label")]
 process_mode = 3
+z_index = 1000
 script = ExtResource("1_b8dw1")
 screen_message = NodePath("CanvasLayer/MarginContainer/PanelContainer/MarginContainer/HBoxContainer/LoadingMessage")
 static_label = NodePath("CanvasLayer/MarginContainer/PanelContainer/MarginContainer/HBoxContainer/LoadingStatic")
 sound_effect = ExtResource("2_b0kc6")
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
-layer = 120
+layer = 127
 
 [node name="MarginContainer" type="MarginContainer" parent="CanvasLayer"]
 anchors_preset = 15
@@ -70,8 +71,10 @@ spawn_template = ExtResource("3_d4esl")
 spawn_target = NodePath("../../CardNode")
 
 [node name="CardNode" type="Node2D" parent="."]
+z_index = 1000
 
 [node name="BackgroundLayer" type="CanvasLayer" parent="."]
 layer = -3
 
 [node name="MenuBackground" parent="BackgroundLayer" instance=ExtResource("5_0ob53")]
+z_index = -3

--- a/scenes/game/levels/MemoryGameScene.tscn
+++ b/scenes/game/levels/MemoryGameScene.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=27 format=3 uid="uid://bnfr8gek24m47"]
+[gd_scene load_steps=26 format=3 uid="uid://bnfr8gek24m47"]
 
 [ext_resource type="Script" uid="uid://bhgb4virmkji8" path="res://src/game/MemoryGame.gd" id="1_13jq5"]
 [ext_resource type="AudioStream" uid="uid://dj5j3cwv0a265" path="res://assets/audio/effect/card-slide-1.ogg" id="2_2td5d"]
@@ -17,7 +17,6 @@
 [ext_resource type="AudioStream" uid="uid://dhm4p2ecwyfl3" path="res://assets/audio/effect/card-slide-7.ogg" id="8_x5jru"]
 [ext_resource type="AudioStream" uid="uid://duqacxqgecl83" path="res://assets/audio/effect/card-slide-8.ogg" id="9_2ngk1"]
 [ext_resource type="PackedScene" uid="uid://cluwm03j8e11p" path="res://scenes/game/overlay/GamePauseMenu.tscn" id="12_dfx06"]
-[ext_resource type="PackedScene" uid="uid://bv4jg7bjubrrr" path="res://scenes/game/levels/LoadingScreen.tscn" id="12_v3o3x"]
 [ext_resource type="Script" uid="uid://c3hyh8ifpeuxg" path="res://src/game/ai/GameAI.gd" id="15_u3ner"]
 [ext_resource type="Texture2D" uid="uid://b6xl5vukmvlku" path="res://assets/icons/AddIcon.tres" id="18_pqxyo"]
 [ext_resource type="Script" uid="uid://c51fjvpbl3jd0" path="res://src/menu/touch/TouchButton.gd" id="18_u7amr"]
@@ -27,7 +26,7 @@
 [ext_resource type="Script" uid="uid://boch5lqi4lvc7" path="res://src/game/tutorial/Tutorial.gd" id="22_0x2pf"]
 [ext_resource type="PackedScene" uid="uid://d15qeu4s4bgjk" path="res://scenes/game/templates/TutorialWindow.tscn" id="22_ubsrg"]
 
-[node name="MemoryGame" type="Node2D" node_paths=PackedStringArray("gui_node", "card_target_node", "game_nodes_to_show", "loading_scene")]
+[node name="MemoryGame" type="Node2D" node_paths=PackedStringArray("gui_node", "card_target_node", "game_nodes_to_show")]
 process_mode = 1
 script = ExtResource("1_13jq5")
 card_lay_sounds = Array[AudioStream]([ExtResource("2_2td5d"), ExtResource("3_hm6tj"), ExtResource("4_2dnnm"), ExtResource("5_0pbsf"), ExtResource("6_heint"), ExtResource("7_f7bl6"), ExtResource("8_x5jru"), ExtResource("9_2ngk1")])
@@ -37,7 +36,6 @@ finished_game_template = ExtResource("4_6f670")
 game_menu_template = ExtResource("12_dfx06")
 card_target_node = NodePath("Cards")
 game_nodes_to_show = [NodePath("CanvasLayer"), NodePath("Background")]
-loading_scene = NodePath("Camera2D/LoadingScreen")
 
 [node name="Players" type="Node" parent="."]
 unique_name_in_owner = true
@@ -52,9 +50,6 @@ min_wait_milliseconds = 750.0
 [node name="Camera2D" type="Camera2D" parent="."]
 position = Vector2(600, 0)
 script = ExtResource("4_4ihyn")
-
-[node name="LoadingScreen" parent="Camera2D" groups=["game_initialize_scene"] instance=ExtResource("12_v3o3x")]
-position = Vector2(-960, -540)
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 process_mode = 3
@@ -134,6 +129,7 @@ script = ExtResource("19_ploi3")
 position = Vector2(-11367, -8587)
 is_ghost = true
 
+[connection signal="card_loading_done" from="." to="Camera2D" method="loading_done"]
 [connection signal="card_loading_done" from="." to="CanvasLayer/MenuButton" method="show_button"]
 [connection signal="card_loading_done" from="." to="CanvasLayer/MarginContainer/PlayersOverlay" method="show"]
 [connection signal="card_loading_done" from="." to="CanvasLayer/VBoxContainer/ZoomIn" method="show_button"]
@@ -165,7 +161,6 @@ is_ghost = true
 [connection signal="card_movement" from="Camera2D" to="Cards" method="parse_movement"]
 [connection signal="confirm_current_card" from="Camera2D" to="Cards" method="confirm_current_card"]
 [connection signal="game_menu_requested" from="Camera2D" to="." method="show_game_menu"]
-[connection signal="loading_done" from="Camera2D/LoadingScreen" to="Camera2D" method="loading_done"]
 [connection signal="continue_game" from="CanvasLayer/PopupManager" to="." method="unpause_game"]
 [connection signal="pause_game" from="CanvasLayer/PopupManager" to="." method="pause_game"]
 [connection signal="tutorial_requested" from="CanvasLayer/Tutorial" to="CanvasLayer/PopupManager" method="add_and_show_popup"]

--- a/scenes/game/overlay/GamePauseMenu.tscn
+++ b/scenes/game/overlay/GamePauseMenu.tscn
@@ -8,7 +8,7 @@
 [ext_resource type="Shortcut" uid="uid://2i2jk61uyyn2" path="res://assets/shortcuts/Abort.tres" id="3_vcfmt"]
 [ext_resource type="Texture2D" uid="uid://b6vwa7x6vgpfd" path="res://assets/icons/DenyIcon.tres" id="6_34hpv"]
 
-[node name="GamePauseMenu" type="Control"]
+[node name="GamePauseMenu" type="Control" groups=["active_scene"]]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0

--- a/scenes/global/BurnScreenTransition.tscn
+++ b/scenes/global/BurnScreenTransition.tscn
@@ -39,6 +39,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+mouse_filter = 2
 texture = SubResource("GradientTexture1D_pg0ff")
 script = ExtResource("3_pg0ff")
 shader_progress_control_name = "radius"

--- a/src/game/CameraController.gd
+++ b/src/game/CameraController.gd
@@ -35,9 +35,10 @@ func _ready():
 	process_mode = Node.PROCESS_MODE_DISABLED
 
 func loading_done():
-	zoom = initial_zoom
-	position = initial_position
 	process_mode = Node.PROCESS_MODE_INHERIT
+	position = initial_position
+	var tween = create_tween()
+	tween.tween_property(self, "zoom", initial_zoom, 1.0)
 
 func _input(event):
 	if event is InputEventScreenDrag:

--- a/src/game/CardTemplate.gd
+++ b/src/game/CardTemplate.gd
@@ -54,7 +54,8 @@ func _enter_tree():
 		printerr("No parent node was found!")
 		return
 
-	parent_node.game_state_changed.connect(state_changed)
+	if !parent_node.game_state_changed.is_connected(state_changed):
+		parent_node.game_state_changed.connect(state_changed)
 
 func toggle_card_on():
 	var time_range = max_time_delay - min_time_delay

--- a/src/game/MemoryGame.gd
+++ b/src/game/MemoryGame.gd
@@ -36,7 +36,6 @@ const CARDS_PER_PLAYER = 2
 @export var card_target_node: Node2D
 
 @export var game_nodes_to_show: Array[Node]
-@export var loading_scene: LoadingScreen
 
 var current_game_state
 var player_node: PlayerManager
@@ -55,7 +54,6 @@ var last_message_banner_id: int = -1
 
 func _ready():
 	process_mode = PROCESS_MODE_DISABLED
-	loading_scene.set_screen_message("PLACING_CARDS", true)
 	current_sound_timer = seconds_to_lay_cards
 	
 	player_node = get_node("%Players")
@@ -72,16 +70,16 @@ func start_loading_data():
 	var cards = load_thread.wait_to_finish() as Array[CardTemplate]
 	for card in cards:
 		card_target_node.add_child(card)
+		card.visible = false
 		card.card_triggered.connect(card_was_triggered)
 	load_thread = null
 	card_loading_done.emit()
+	for card in cards:
+		card.visible = true
 	start_round_now()
 		
 	for child in get_tree().get_nodes_in_group("game_initialize_scene"):
-		if child is LoadingScreen:
-			loading_scene.destory()
-		else:
-			child.queue_free()
+		child.queue_free()
 	for node in game_nodes_to_show:
 		if node is Node2D:
 			node.visible = true 

--- a/src/game/data_loading/SystemDeckManager.gd
+++ b/src/game/data_loading/SystemDeckManager.gd
@@ -2,11 +2,10 @@ extends Node2D
 
 class_name SystemDeckManager
 
-
 signal loading_system_decks()
 signal loading_system_decks_done()
 
-const CHECK_INTERVALL_SECONDS: float = 2
+const CHECK_INTERVAL_SECONDS: float = 2
 var elapsed_time = 0
 var system_decks: Array[MemoryDeckResource] = []
 var load_threads: Array[Thread] = []
@@ -41,7 +40,7 @@ func _process(delta):
 	var deck_id: int = 1000
 	if is_loading():
 		elapsed_time = elapsed_time + delta
-		if elapsed_time < CHECK_INTERVALL_SECONDS:
+		if elapsed_time < CHECK_INTERVAL_SECONDS:
 			return
 		elapsed_time = 0
 		var loading_done = true

--- a/src/game/overlay/GamePauseMenu.gd
+++ b/src/game/overlay/GamePauseMenu.gd
@@ -1,5 +1,6 @@
 class_name GamePauseMenu extends PopupWindow
 
+@warning_ignore("unused_signal")
 signal close_pause_menu()
 
 func close_menu():

--- a/src/game/overlay/PopupWindow.gd
+++ b/src/game/overlay/PopupWindow.gd
@@ -1,5 +1,6 @@
 class_name PopupWindow extends Control
 
+@warning_ignore("unused_signal")
 signal popup_closed()
 
 var id: int = -1

--- a/src/menu/generic/OpenSingleScene.gd
+++ b/src/menu/generic/OpenSingleScene.gd
@@ -6,8 +6,6 @@ extends ClickableButton
 func _pressed():
 	super()
 	if transmit_click_position:
-		
 		ScreenTransitionManager.transit_screen_with_position(scene_template, get_global_center_position())
 		return
 	ScreenTransitionManager.transit_screen(scene_template)
-	#GlobalGameManagerAccess.get_game_manager().open_menu(scene_template)

--- a/src/shared/ScreenTransitionManager.gd
+++ b/src/shared/ScreenTransitionManager.gd
@@ -8,8 +8,9 @@ func _get_transition_scene() -> PackedScene:
 		return low_performance_scene
 	return animation_scene
 
-func _create_animation_scene_instance() -> AnimationScene:
+func _create_animation_scene_instance(add_to_active_scene: bool = true) -> AnimationScene:
 	var scene = _get_transition_scene().instantiate() as AnimationScene
+	scene.add_to_active_scene = add_to_active_scene
 	scene.animation_done.connect(_animation_done)
 	get_tree().root.add_child(scene)
 	get_tree().root.move_child(scene, 0)
@@ -19,24 +20,22 @@ func _create_animation_scene_instance() -> AnimationScene:
 func _animation_done(scene: Node):
 	scene.queue_free()
 
-
-
-func transit_screen_with_position(new_scene: PackedScene, position: Vector2) -> AnimationScene:
+func transit_screen_with_position(new_scene: PackedScene, position: Vector2, add_to_active_scene: bool = true) -> AnimationScene:
 	await RenderingServer.frame_post_draw
 	var old_texture: Texture = ImageTexture.create_from_image( get_viewport().get_texture().get_image() )
-	var scene = _create_animation_scene_instance()
+	var scene = _create_animation_scene_instance(add_to_active_scene)
 	scene.change_screen_to(new_scene, old_texture, position)
 	return scene
 
-func transit_screen(new_scene: PackedScene) -> AnimationScene:
-	return await transit_screen_with_position(new_scene, Vector2.ZERO)
+func transit_screen(new_scene: PackedScene, add_to_active_scene: bool = true) -> AnimationScene:
+	return await transit_screen_with_position(new_scene, Vector2.ZERO, add_to_active_scene)
 
-func transit_screen_by_node_with_position(new_scene: Node, position: Vector2) -> AnimationScene:
+func transit_screen_by_node_with_position(new_scene: Node, position: Vector2 , add_to_active_scene: bool = true) -> AnimationScene:
 	await RenderingServer.frame_post_draw
 	var old_texture: Texture = ImageTexture.create_from_image( get_viewport().get_texture().get_image() )
-	var scene = _create_animation_scene_instance()
+	var scene = _create_animation_scene_instance(add_to_active_scene)
 	scene.change_screen_to_node(new_scene, old_texture, position)
 	return scene
 
-func transit_screen_by_node(new_scene: Node) -> AnimationScene:
-	return await transit_screen_by_node_with_position(new_scene, Vector2.ZERO)
+func transit_screen_by_node(new_scene: Node , add_to_active_scene: bool = true) -> AnimationScene:
+	return await transit_screen_by_node_with_position(new_scene, Vector2.ZERO, add_to_active_scene)

--- a/src/templates/animation/ControlAnimationResource.gd
+++ b/src/templates/animation/ControlAnimationResource.gd
@@ -4,13 +4,13 @@ class_name ControlAnimationResource extends Resource
 
 var animated_in: bool
 
-func prepare_animation(control: Control):
+func prepare_animation(_control: Control):
 	pass
 
-func animate_in(tween: Tween, control: Control):
+func animate_in(_tween: Tween, _control: Control):
 	animated_in = true
 
-func animate_out(tween: Tween, control: Control):
+func animate_out(_tween: Tween, _control: Control):
 	animated_in = false
 
 func is_animated_in() -> bool:


### PR DESCRIPTION
fix a few Godot warnings
fix spelling

This commit will add transitions from the loading screen to other parts of the game. This should make the overall experience feel more natural and polished.