### PR TITLE
fix: reset tutorial did not work correctly

### DIFF
--- a/scenes/menu/SettingsMenu.tscn
+++ b/scenes/menu/SettingsMenu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=30 format=3 uid="uid://ded0xyxbb1om1"]
+[gd_scene load_steps=29 format=3 uid="uid://ded0xyxbb1om1"]
 
 [ext_resource type="PackedScene" uid="uid://cgqyilfj4ggfa" path="res://scenes/menu/MenuBackground.tscn" id="2_cootk"]
 [ext_resource type="Script" uid="uid://be1ipi8ub0y8n" path="res://src/menu/settings_menu/SettingsMenu.gd" id="2_hfhds"]
@@ -25,7 +25,6 @@
 [ext_resource type="AudioStream" uid="uid://48iu01xst023" path="res://assets/audio/effect/card-turn-2.ogg" id="14_vb64j"]
 [ext_resource type="AudioStream" uid="uid://h0louy6yrv3o" path="res://assets/audio/effect/card-turn-3.ogg" id="15_b5nta"]
 [ext_resource type="Script" uid="uid://chfatpxf8ucxr" path="res://src/menu/control_overwrites/ClickableButton.gd" id="19_3ip51"]
-[ext_resource type="Script" uid="uid://bx11dlcw4bqx4" path="res://src/menu/settings_menu/ResetTutorial.gd" id="20_wiovc"]
 [ext_resource type="Texture2D" uid="uid://dqv4i4y66gem" path="res://assets/icons/OkIcon.tres" id="26_br808"]
 [ext_resource type="Shortcut" uid="uid://2i2jk61uyyn2" path="res://assets/shortcuts/Abort.tres" id="28_12fsg"]
 [ext_resource type="Texture2D" uid="uid://b6vwa7x6vgpfd" path="res://assets/icons/DenyIcon.tres" id="28_mbv6n"]
@@ -137,7 +136,8 @@ layout_mode = 2
 tooltip_text = "RESET_TUTORIAL_TOOLTIP"
 text = "RESET_TUTORIAL"
 icon = ExtResource("10_mdkqv")
-script = ExtResource("20_wiovc")
+script = ExtResource("19_3ip51")
+can_multi_click = false
 
 [node name="PanelContainer" type="PanelContainer" parent="CenterContainer/PanelContainer/MarginContainer/VBoxContainer2/HBoxContainer"]
 custom_minimum_size = Vector2(350, 0)
@@ -230,6 +230,7 @@ can_multi_click = false
 [connection signal="toggled" from="CenterContainer/PanelContainer/MarginContainer/VBoxContainer2/HBoxContainer/GameSettings/VBoxContainer/HBoxContainer2/AutoCompleteRound" to="CenterContainer/PanelContainer/MarginContainer/VBoxContainer2/HBoxContainer/GameSettings/VBoxContainer/HBoxContainer2/TimeForCompletionGroup" method="toggle_visibility"]
 [connection signal="value_changed" from="CenterContainer/PanelContainer/MarginContainer/VBoxContainer2/HBoxContainer/GameSettings/VBoxContainer/HBoxContainer2/TimeForCompletionGroup/TimeForCompletionSlider" to="." method="time_for_completion_changed"]
 [connection signal="value_changed" from="CenterContainer/PanelContainer/MarginContainer/VBoxContainer2/HBoxContainer/GameSettings/VBoxContainer/HBoxContainer2/TimeForCompletionGroup/TimeForCompletionSlider" to="CenterContainer/PanelContainer/MarginContainer/VBoxContainer2/HBoxContainer/GameSettings/VBoxContainer/HBoxContainer2/TimeForCompletionGroup" method="slider_changed"]
+[connection signal="pressed" from="CenterContainer/PanelContainer/MarginContainer/VBoxContainer2/HBoxContainer/GameSettings/VBoxContainer/ResetTutorial" to="." method="reset_tutorial"]
 [connection signal="volume_changed" from="CenterContainer/PanelContainer/MarginContainer/VBoxContainer2/HBoxContainer/PanelContainer/VBoxContainer/Audio Control/Master" to="." method="volume_changed"]
 [connection signal="volume_changed" from="CenterContainer/PanelContainer/MarginContainer/VBoxContainer2/HBoxContainer/PanelContainer/VBoxContainer/Audio Control/Effects" to="." method="volume_changed"]
 [connection signal="volume_changed" from="CenterContainer/PanelContainer/MarginContainer/VBoxContainer2/HBoxContainer/PanelContainer/VBoxContainer/Audio Control/Music" to="." method="volume_changed"]

--- a/src/menu/settings_menu/ResetTutorial.gd
+++ b/src/menu/settings_menu/ResetTutorial.gd
@@ -1,9 +1,0 @@
-extends ClickableButton
-
-func _pressed():
-	super()
-	var settings = SettingsRepository.load_settings() as SettingsResource
-	settings.tutorials = {}
-	settings.tutorial_aborted = false
-	settings.auto_close_popup_shown = false
-	SettingsRepository.save_settings(settings)

--- a/src/menu/settings_menu/ResetTutorial.gd.uid
+++ b/src/menu/settings_menu/ResetTutorial.gd.uid
@@ -1,1 +1,0 @@
-uid://bx11dlcw4bqx4

--- a/src/menu/settings_menu/SettingsMenu.gd
+++ b/src/menu/settings_menu/SettingsMenu.gd
@@ -18,6 +18,11 @@ func reset_settings():
 	settings_loaded.emit(initial_settings)
 	close_window(close_button)
 
+func reset_tutorial():
+	current_settings.tutorials = {}
+	current_settings.tutorial_aborted = false
+	current_settings.auto_close_popup_shown = false
+
 func save_settings():
 	var window_mode = DisplayServer.window_get_mode()
 	current_settings.fullscreen = false


### PR DESCRIPTION
There was a issue with the reset tutorial button, it only did work if the settings was aborted afterward. This is now solved.