### PR TITLE
feat: improve build pipeline

### DIFF
--- a/.github/workflows/create-live-build.yml
+++ b/.github/workflows/create-live-build.yml
@@ -94,7 +94,7 @@ jobs:
   upload-itch:
     name: Upload to itch
     runs-on: ubuntu-latest
-    needs: ["upload-release"]
+    needs: ["build"]
     strategy:
       matrix:
         platform:


### PR DESCRIPTION
Changing the build pipeline to allow itch and GitHub upload to run in parallel, this should cut the time required for the build.