### PR TITLE
feat: hide deck preview reload custom deck button

### DIFF
--- a/src/menu/deck_viewer/ReloadDecks.gd
+++ b/src/menu/deck_viewer/ReloadDecks.gd
@@ -14,6 +14,7 @@ func _ready():
 	if OS.has_feature("web") or !settings.load_custom_decks:
 		is_locked = true
 		disabled = true
+		queue_free()
 
 func enable_button():
 	if is_locked:


### PR DESCRIPTION
The button will be hidden if you are running a web build as it is not possible to side load any decks from within that configuration.